### PR TITLE
add FromBytes() into BloomFilter

### DIFF
--- a/bloom/bloom2048b.go
+++ b/bloom/bloom2048b.go
@@ -27,6 +27,7 @@ func newBloom2048(h uint) (BloomFilter, error) {
 	return &bloom2048b{numHash: h}, nil
 }
 
+// FromBytes loads data in the struct
 func (b *bloom2048b) FromBytes(data []byte) error {
 	if b.numHash == 0 || b.numHash > 16 {
 		return errors.New("expecting 0 < number of hash functions <= 16")

--- a/bloom/bloom2048b.go
+++ b/bloom/bloom2048b.go
@@ -27,14 +27,13 @@ func newBloom2048(h uint) (BloomFilter, error) {
 	return &bloom2048b{numHash: h}, nil
 }
 
-func (b *bloom2048b) FromBytes(data []byte, h uint) error {
-	if h == 0 || h > 16 {
+func (b *bloom2048b) FromBytes(data []byte) error {
+	if b.numHash == 0 || b.numHash > 16 {
 		return errors.New("expecting 0 < number of hash functions <= 16")
 	}
 	if len(data) != 256 {
 		return errors.Errorf("wrong length %d, expecting 256", len(data))
 	}
-	b.numHash = h
 	copy(b.array[:], data[:])
 	return nil
 }

--- a/bloom/bloom2048b.go
+++ b/bloom/bloom2048b.go
@@ -27,17 +27,16 @@ func newBloom2048(h uint) (BloomFilter, error) {
 	return &bloom2048b{numHash: h}, nil
 }
 
-// bloom2048FromBytes constructs a 2048-bit bloom filter from bytes
-func bloom2048FromBytes(b []byte, h uint) (BloomFilter, error) {
+func (b *bloom2048b) FromBytes(data []byte, h uint) error {
 	if h == 0 || h > 16 {
-		return nil, errors.New("expecting 0 < number of hash functions <= 16")
+		return errors.New("expecting 0 < number of hash functions <= 16")
 	}
-	if len(b) != 256 {
-		return nil, errors.Errorf("wrong length %d, expecting 256", len(b))
+	if len(data) != 256 {
+		return errors.Errorf("wrong length %d, expecting 256", len(data))
 	}
-	f := bloom2048b{numHash: h}
-	copy(f.array[:], b[:])
-	return &f, nil
+	b.numHash = h
+	copy(b.array[:], data[:])
+	return nil
 }
 
 // Size of bloom filter in bits

--- a/bloom/bloom_m.go
+++ b/bloom/bloom_m.go
@@ -183,14 +183,13 @@ func (b *bloomMbits) FromBytes(data []byte) error {
 	bucketsLen := (m + 63) >> 6
 	if bucketsLen > uint64(cap(b.buckets)) {
 		b.buckets = make([]uint64, bucketsLen)
+	} else {
+		b.buckets = b.buckets[:bucketsLen]
 	}
-	b.buckets = b.buckets[:bucketsLen]
 	if err := binary.Read(buf, binary.BigEndian, b.buckets); err != nil {
 		return err
 	}
 
-	b.m, b.k, b.n = m, k, n
-	b.round = b.k >> 2
-	b.rem = int(b.k & 3)
+	b.m, b.k, b.n, b.round, b.rem = m, k, n, k>>2, int(k&3)
 	return nil
 }

--- a/bloom/bloom_m.go
+++ b/bloom/bloom_m.go
@@ -159,7 +159,7 @@ func (b *bloomMbits) getBit(pos uint64) byte {
 }
 
 // FromBytes loads data in the struct
-func (b *bloomMbits) FromBytes(data []byte, _ uint) error {
+func (b *bloomMbits) FromBytes(data []byte) error {
 	// last 32 bytes is hash of preceding data
 	dataLength := len(data) - 32
 	wantedHash := hash.BytesToHash256(data[dataLength:])

--- a/bloom/bloom_m_test.go
+++ b/bloom/bloom_m_test.go
@@ -46,7 +46,7 @@ func TestBloomMbits(t *testing.T) {
 
 		// decode and verify
 		newBF := bloomMbits{}
-		err = newBF.FromBytes(b, 0)
+		err = newBF.FromBytes(b)
 		require.NoError(err)
 		for i := uint64(0); i < v.n; i++ {
 			k := hash.Hash256b(byteutil.Uint64ToBytesBigEndian(i))
@@ -66,18 +66,18 @@ func TestBloomMbits(t *testing.T) {
 		bTmp := make([]byte, len(b))
 		copy(bTmp, b)
 		bTmp[len(b)-1]++
-		err = newBF.FromBytes(bTmp, 0)
+		err = newBF.FromBytes(bTmp)
 		require.Equal(ErrHashMismatch, errors.Cause(err))
 
 		// not enough data
 		bTmp = bTmp[1 : len(b)-32]
 		h = hash.Hash256b(bTmp)
 		bTmp = append(bTmp, h[:]...)
-		err = newBF.FromBytes(bTmp, 0)
+		err = newBF.FromBytes(bTmp)
 		require.Equal(io.ErrUnexpectedEOF, errors.Cause(err))
 
 		// verify again
-		err = newBF.FromBytes(b, 0)
+		err = newBF.FromBytes(b)
 		require.NoError(err)
 		for i := uint64(0); i < v.n; i++ {
 			k := hash.Hash256b(byteutil.Uint64ToBytesBigEndian(i))

--- a/bloom/bloomfilter.go
+++ b/bloom/bloomfilter.go
@@ -30,6 +30,9 @@ type (
 
 		// Bytes returns the bytes of bloom filter
 		Bytes() []byte
+
+		// FromBytes loads data into the struct
+		FromBytes([]byte, uint) error
 	}
 )
 
@@ -44,22 +47,7 @@ func NewBloomFilterLegacy(m, h uint) (BloomFilter, error) {
 	}
 }
 
-// BloomFilterFromBytesLegacy constructs a bloom filter from bytes
-func BloomFilterFromBytesLegacy(b []byte, m, h uint) (BloomFilter, error) {
-	switch m {
-	case 2048:
-		return bloom2048FromBytes(b, h)
-	default:
-		return nil, errors.Errorf("bloom filter size %d not supported", m)
-	}
-}
-
 // NewBloomFilter returns a new bloom filter
 func NewBloomFilter(m, h uint64) (BloomFilter, error) {
 	return newBloomMbits(m, h)
-}
-
-// BloomFilterFromBytes constructs a bloom filter from bytes
-func BloomFilterFromBytes(buf []byte) (BloomFilter, error) {
-	return bloomMbitsFromBytes(buf)
 }

--- a/bloom/bloomfilter.go
+++ b/bloom/bloomfilter.go
@@ -32,7 +32,7 @@ type (
 		Bytes() []byte
 
 		// FromBytes loads data into the struct
-		FromBytes([]byte, uint) error
+		FromBytes([]byte) error
 	}
 )
 


### PR DESCRIPTION
 - Remove `BloomFilterFromBytesLegacy()` and `BloomFilterFromBytes()`
 - Loading the data directly into BloomFilter to reuse the allocated memory