### PR TITLE
refactor k256 pubkey

### DIFF
--- a/crypto/secp256k1.go
+++ b/crypto/secp256k1.go
@@ -24,7 +24,7 @@ type (
 	}
 	// secp256k1PubKey implements the SECP256K1 public key
 	secp256k1PubKey struct {
-		*ecdsa.PublicKey
+		raw []byte
 	}
 )
 
@@ -72,7 +72,7 @@ func (k *secp256k1PrvKey) EcdsaPrivateKey() interface{} {
 // PublicKey returns the public key corresponding to private key
 func (k *secp256k1PrvKey) PublicKey() PublicKey {
 	return &secp256k1PubKey{
-		PublicKey: &k.PrivateKey.PublicKey,
+		raw: crypto.FromECDSAPub(&k.PrivateKey.PublicKey),
 	}
 }
 
@@ -95,18 +95,30 @@ func (k *secp256k1PrvKey) Zero() {
 
 // newSecp256k1PubKeyFromBytes converts bytes format to PublicKey
 func newSecp256k1PubKeyFromBytes(b []byte) (PublicKey, error) {
-	pk, err := crypto.UnmarshalPubkey(b)
-	if err != nil {
-		return nil, err
+	if !validateRawK256Pubkey(b) {
+		return nil, ErrPublicKey
 	}
+
 	return &secp256k1PubKey{
-		PublicKey: pk,
+		raw: b,
 	}, nil
+}
+
+func validateRawK256Pubkey(data []byte) bool {
+	byteLen := (crypto.S256().Params().BitSize + 7) >> 3
+	if len(data) != 1+2*byteLen {
+		return false
+	}
+	if data[0] != 4 { // uncompressed form
+		return false
+	}
+
+	return true
 }
 
 // Bytes returns the public key in bytes representation
 func (k *secp256k1PubKey) Bytes() []byte {
-	return crypto.FromECDSAPub(k.PublicKey)
+	return k.raw
 }
 
 // HexString returns the public key in hex string
@@ -116,7 +128,12 @@ func (k *secp256k1PubKey) HexString() string {
 
 // EcdsaPublicKey returns the embedded ecdsa publick key
 func (k *secp256k1PubKey) EcdsaPublicKey() interface{} {
-	return k.PublicKey
+	pk, err := crypto.UnmarshalPubkey(k.raw)
+	if err != nil {
+		// it should be validated when initialized
+		panic(err)
+	}
+	return pk
 }
 
 // Hash is the last 20-byte of keccak hash of public key (X, Y) co-ordinate, same as Ethereum address generation

--- a/crypto/secp256k1.go
+++ b/crypto/secp256k1.go
@@ -93,6 +93,10 @@ func (k *secp256k1PrvKey) Zero() {
 // PublicKey function
 //======================================
 
+var (
+	secp256k1PubKeyByteLen = (crypto.S256().Params().BitSize + 7) >> 3
+)
+
 // newSecp256k1PubKeyFromBytes converts bytes format to PublicKey
 func newSecp256k1PubKeyFromBytes(b []byte) (PublicKey, error) {
 	if !validateRawK256Pubkey(b) {
@@ -105,8 +109,7 @@ func newSecp256k1PubKeyFromBytes(b []byte) (PublicKey, error) {
 }
 
 func validateRawK256Pubkey(data []byte) bool {
-	byteLen := (crypto.S256().Params().BitSize + 7) >> 3
-	if len(data) != 1+2*byteLen {
+	if len(data) != 1+2*secp256k1PubKeyByteLen {
 		return false
 	}
 	if data[0] != 4 { // uncompressed form

--- a/crypto/secp256k1.go
+++ b/crypto/secp256k1.go
@@ -99,7 +99,7 @@ var (
 
 // newSecp256k1PubKeyFromBytes converts bytes format to PublicKey
 func newSecp256k1PubKeyFromBytes(b []byte) (PublicKey, error) {
-	if !validateRawK256Pubkey(b) {
+	if !validateP256k1PubkeyBytes(b) {
 		return nil, ErrPublicKey
 	}
 
@@ -108,7 +108,7 @@ func newSecp256k1PubKeyFromBytes(b []byte) (PublicKey, error) {
 	}, nil
 }
 
-func validateRawK256Pubkey(data []byte) bool {
+func validateP256k1PubkeyBytes(data []byte) bool {
 	if len(data) != 1+2*secp256k1PubKeyByteLen {
 		return false
 	}

--- a/crypto/secp256k1_test.go
+++ b/crypto/secp256k1_test.go
@@ -69,3 +69,19 @@ func TestSecp256k1(t *testing.T) {
 	require.Equal("53fbc28faf9a52dfe5f591948a23189e900381b5", hex.EncodeToString(pk.Hash()))
 
 }
+
+func BenchmarkSecp256k1(b *testing.B) {
+	require := require.New(b)
+
+	sk, err := newSecp256k1PrvKey()
+	require.NoError(err)
+	defer sk.Zero()
+	pk := sk.PublicKey()
+	require.Equal(secp256pubKeyLength, len(pk.Bytes()))
+	b.ResetTimer()
+	pkData := pk.Bytes()
+	for n := 0; n < b.N; n++ {
+		_, err := newSecp256k1PubKeyFromBytes(pkData)
+		require.NoError(err)
+	}
+}


### PR DESCRIPTION
solve the root cause of https://github.com/iotexproject/go-pkgs/pull/39
The result of benchmark

```
BenchmarkSecp256k1-12             100000               551.0 ns/op             0 B/op          0 allocs/op
PASS
```

<img width="1771" alt="image" src="https://github.com/iotexproject/go-pkgs/assets/55118568/e83b0e36-fe17-4c10-b64e-bd55b4bcf889">
